### PR TITLE
Fix getResoruceCall to Graph API - which is way faster and only 1 call.

### DIFF
--- a/src/commands/utils/azureResources.ts
+++ b/src/commands/utils/azureResources.ts
@@ -1,9 +1,10 @@
 import { GenericResourceExpanded } from "@azure/arm-resources";
-import { getResourceManagementClient, listAll, getAksFleetClient } from "./arm";
+import { getResourceManagementClient, listAll, getAksFleetClient, getGraphResourceClient } from "./arm";
 import { Errorable, map as errmap } from "./errorable";
 import { parseResource } from "../../azure-api-utils";
 import { ReadyAzureSessionProvider } from "../../auth/types";
 import { FleetMember } from "@azure/arm-containerservicefleet";
+import { AksCluster } from "./config";
 
 export const clusterProvider = "Microsoft.ContainerService";
 export const acrProvider = "Microsoft.ContainerRegistry";
@@ -48,6 +49,34 @@ export async function getResources(
     const client = getResourceManagementClient(sessionProvider, subscriptionId);
     const list = await listAll(client.resources.list({ filter: `resourceType eq '${resourceType}'` }));
     return errmap(list, (resources) => resources.filter(isDefinedResource).map(asResourceWithGroup));
+}
+
+export async function getClusterAndFleetResourcesFromGraphAPI(
+    sessionProvider: ReadyAzureSessionProvider,
+    subscriptionId: string,
+): Promise<Errorable<AksCluster[]>> {
+    const client = getGraphResourceClient(sessionProvider);
+    const query = {
+        query: `Resources | where type =~ '${clusterResourceType}' or type =~ '${fleetResourceType}' | project id, name, location, resourceGroup, subscriptionId, type`,
+        subscriptions: [subscriptionId],
+    };
+
+    try {
+        const response = await client.resources(query);
+
+        const aksClusters: AksCluster[] = response.data.map((resource: AksCluster) => ({
+            id: resource.id,
+            name: resource.name,
+            location: resource.location,
+            resourceGroup: resource.resourceGroup,
+            subscriptionId: resource.subscriptionId,
+            type: resource.type,
+        }));
+        return errmap({ succeeded: true, result: aksClusters }, (resources) => resources);
+    } catch (error) {
+        console.error("Error fetching AKS clusters:", error);
+        return { succeeded: false, error: error as string };
+    }
 }
 
 function isDefinedResource(resource: GenericResourceExpanded): resource is DefinedResource {

--- a/src/commands/utils/clusterfilter.ts
+++ b/src/commands/utils/clusterfilter.ts
@@ -8,7 +8,6 @@ import { longRunning } from "../utils/host";
 import { getGraphResourceClient } from "../utils/arm";
 import { getReadySessionProvider } from "../../auth/azureAuth";
 import { AksCluster, getFilteredClusters, setFilteredClusters } from "./config";
-import { parseResource, parseSubId } from "../../azure-api-utils";
 import { ResourceGraphClient } from "@azure/arm-resourcegraph";
 
 export default async function aksClusterFilter(_context: IActionContext, target: unknown): Promise<void> {

--- a/src/commands/utils/clusterfilter.ts
+++ b/src/commands/utils/clusterfilter.ts
@@ -78,7 +78,7 @@ async function fetchAksClusters(
     subscriptionId: string,
 ): Promise<AksCluster[]> {
     const query = {
-        query: "Resources | where type =~ 'Microsoft.ContainerService/managedClusters' | project name, location, resourceGroup, subscriptionId",
+        query: "Resources | where type =~ 'Microsoft.ContainerService/managedClusters' | project id, name, location, resourceGroup, subscriptionId, type",
         subscriptions: [subscriptionId],
     };
 
@@ -91,6 +91,7 @@ async function fetchAksClusters(
             location: resource.location,
             resourceGroup: resource.resourceGroup,
             subscriptionId: resource.subscriptionId,
+            type: resource.type,
         }));
 
         return aksClusters;

--- a/src/commands/utils/config.ts
+++ b/src/commands/utils/config.ts
@@ -51,6 +51,7 @@ export interface AksCluster {
     location: string;
     resourceGroup: string;
     subscriptionId: string;
+    type: string;
 }
 
 const onFilteredSubscriptionsChangeEmitter = new vscode.EventEmitter<void>();

--- a/src/tree/subscriptionTreeItem.ts
+++ b/src/tree/subscriptionTreeItem.ts
@@ -10,12 +10,10 @@ import { assetUri } from "../assets";
 import * as k8s from "vscode-kubernetes-tools-api";
 import { window } from "vscode";
 import {
-    clusterResourceType,
-    fleetResourceType,
-    getResources,
     getFleetMembers,
     DefinedResourceWithGroup,
     DefinedFleetMemberWithGroup,
+    getClusterAndFleetResourcesFromGraphAPI,
 } from "../commands/utils/azureResources";
 import { failed } from "../commands/utils/errorable";
 import { ReadyAzureSessionProvider } from "../auth/types";
@@ -85,28 +83,28 @@ class SubscriptionTreeItem extends AzExtParentTreeItem implements SubscriptionTr
         clusterResources: DefinedResourceWithGroup[];
         fleetResources: DefinedResourceWithGroup[];
     }> {
-        const clusterResourcesPromise = await getResources(
+        const clusterAndFleetResourcesPromise = await getClusterAndFleetResourcesFromGraphAPI(
             this.sessionProvider,
             this.subscriptionId,
-            clusterResourceType,
         );
-        if (failed(clusterResourcesPromise)) {
-            window.showErrorMessage(
-                `Failed to list clusters in subscription ${this.subscriptionId}: ${clusterResourcesPromise.error}`,
-            );
-            throw clusterResourcesPromise.error;
-        }
-        const clusterResources = filterClusters(clusterResourcesPromise.result);
 
-        const fleetResourcesPromise = await getResources(this.sessionProvider, this.subscriptionId, fleetResourceType);
-        if (failed(fleetResourcesPromise)) {
+        if (failed(clusterAndFleetResourcesPromise)) {
             window.showErrorMessage(
-                `Failed to list fleets in subscription ${this.subscriptionId}: ${fleetResourcesPromise.error}`,
+                `Failed to list clusters or fleets in subscription ${this.subscriptionId}: ${clusterAndFleetResourcesPromise.error}`,
             );
-            throw fleetResourcesPromise.error;
+            throw clusterAndFleetResourcesPromise.error;
         }
 
-        return { clusterResources: clusterResources, fleetResources: fleetResourcesPromise.result };
+        const managedClusters = clusterAndFleetResourcesPromise.result.filter((resource) =>
+            resource.type.includes("managedclusters"),
+        );
+        const fleetsResources = clusterAndFleetResourcesPromise.result.filter((resource) =>
+            resource.type.includes("fleets"),
+        );
+
+        const clusterResources = filterClusters(managedClusters);
+
+        return { clusterResources: clusterResources, fleetResources: fleetsResources };
     }
 
     private async mapFleetAndClusterMembers(fleetResources: DefinedResourceWithGroup[]) {


### PR DESCRIPTION
Second PR. This PR does 2 things: first was: https://github.com/JunyuQian/vscode-aks-tools/pull/2 

* Build Fix here.
* Optimizes multiple `getResources` calls to `getClusterAndFleetResourcesFromGraphAPI` which uses graph API and there is visible difference as well. 

Thanks.