### PR TITLE
Apply/graph work for junyu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
                 "@azure/arm-features": "^3.1.0",
                 "@azure/arm-monitor": "^7.0.0",
                 "@azure/arm-msi": "^2.1.0",
+                "@azure/arm-resourcegraph": "^4.2.1",
                 "@azure/arm-resources": "^5.2.0",
                 "@azure/arm-resources-subscriptions": "^2.1.0",
                 "@azure/arm-storage": "^18.3.0",
@@ -256,6 +257,24 @@
             "engines": {
                 "node": ">=14.0.0"
             }
+        },
+        "node_modules/@azure/arm-resourcegraph": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/@azure/arm-resourcegraph/-/arm-resourcegraph-4.2.1.tgz",
+            "integrity": "sha512-PDuRJ6I7wpy/bu2dqX3OVvX6fpM3YzXkFLGnmYpevYFBQBgueNhHruBAk5r1xh2VRTv1M0lAdaYy6LmVHiCRTw==",
+            "license": "MIT",
+            "dependencies": {
+                "@azure/core-auth": "^1.1.4",
+                "@azure/ms-rest-azure-js": "^2.1.0",
+                "@azure/ms-rest-js": "^2.2.0",
+                "tslib": "^1.10.0"
+            }
+        },
+        "node_modules/@azure/arm-resourcegraph/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "license": "0BSD"
         },
         "node_modules/@azure/arm-resources": {
             "version": "5.2.0",
@@ -578,6 +597,89 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@azure/ms-rest-azure-env/-/ms-rest-azure-env-2.0.0.tgz",
             "integrity": "sha512-dG76W7ElfLi+fbTjnZVGj+M9e0BIEJmRxU6fHaUQ12bZBe8EJKYb2GV50YWNaP2uJiVQ5+7nXEVj1VN1UQtaEw=="
+        },
+        "node_modules/@azure/ms-rest-azure-js": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@azure/ms-rest-azure-js/-/ms-rest-azure-js-2.1.0.tgz",
+            "integrity": "sha512-CjZjB8apvXl5h97Ck6SbeeCmU0sk56YPozPtTyGudPp1RGoHXNjFNtoOvwOG76EdpmMpxbK10DqcygI16Lu60Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@azure/core-auth": "^1.1.4",
+                "@azure/ms-rest-js": "^2.2.0",
+                "tslib": "^1.10.0"
+            }
+        },
+        "node_modules/@azure/ms-rest-azure-js/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "license": "0BSD"
+        },
+        "node_modules/@azure/ms-rest-js": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/@azure/ms-rest-js/-/ms-rest-js-2.7.0.tgz",
+            "integrity": "sha512-ngbzWbqF+NmztDOpLBVDxYM+XLcUj7nKhxGbSU9WtIsXfRB//cf2ZbAG5HkOrhU9/wd/ORRB6lM/d69RKVjiyA==",
+            "license": "MIT",
+            "dependencies": {
+                "@azure/core-auth": "^1.1.4",
+                "abort-controller": "^3.0.0",
+                "form-data": "^2.5.0",
+                "node-fetch": "^2.6.7",
+                "tslib": "^1.10.0",
+                "tunnel": "0.0.6",
+                "uuid": "^8.3.2",
+                "xml2js": "^0.5.0"
+            }
+        },
+        "node_modules/@azure/ms-rest-js/node_modules/form-data": {
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.2.tgz",
+            "integrity": "sha512-GgwY0PS7DbXqajuGf4OYlsrIu3zgxD6Vvql43IBhm6MahqA5SK/7mwhtNj2AdH2z35YR34ujJ7BN+3fFC3jP5Q==",
+            "license": "MIT",
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.6",
+                "mime-types": "^2.1.12",
+                "safe-buffer": "^5.2.1"
+            },
+            "engines": {
+                "node": ">= 0.12"
+            }
+        },
+        "node_modules/@azure/ms-rest-js/node_modules/node-fetch": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+            "license": "MIT",
+            "dependencies": {
+                "whatwg-url": "^5.0.0"
+            },
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            },
+            "peerDependencies": {
+                "encoding": "^0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "encoding": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@azure/ms-rest-js/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "license": "0BSD"
+        },
+        "node_modules/@azure/ms-rest-js/node_modules/uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
         },
         "node_modules/@azure/msal-browser": {
             "version": "3.26.1",
@@ -2247,6 +2349,18 @@
             "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
             "dev": true
         },
+        "node_modules/abort-controller": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+            "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+            "license": "MIT",
+            "dependencies": {
+                "event-target-shim": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=6.5"
+            }
+        },
         "node_modules/acorn": {
             "version": "8.14.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
@@ -2403,8 +2517,7 @@
         "node_modules/asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-            "dev": true
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
         },
         "node_modules/azure-devops-node-api": {
             "version": "12.5.0",
@@ -2983,7 +3096,6 @@
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
             "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-            "dev": true,
             "dependencies": {
                 "delayed-stream": "~1.0.0"
             },
@@ -3261,7 +3373,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-            "dev": true,
             "engines": {
                 "node": ">=0.4.0"
             }
@@ -3769,6 +3880,15 @@
             "devOptional": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/event-target-shim": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+            "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/events": {
@@ -5302,7 +5422,6 @@
             "version": "1.52.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
             "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-            "dev": true,
             "engines": {
                 "node": ">= 0.6"
             }
@@ -5311,7 +5430,6 @@
             "version": "2.1.35",
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
             "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-            "dev": true,
             "dependencies": {
                 "mime-db": "1.52.0"
             },
@@ -6613,8 +6731,7 @@
         "node_modules/sax": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
-            "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
-            "dev": true
+            "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg=="
         },
         "node_modules/schema-utils": {
             "version": "4.2.0",
@@ -7368,6 +7485,12 @@
                 "node": ">=8.0"
             }
         },
+        "node_modules/tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+            "license": "MIT"
+        },
         "node_modules/ts-api-utils": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.0.0.tgz",
@@ -7481,7 +7604,6 @@
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
             "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
-            "dev": true,
             "engines": {
                 "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
             }
@@ -7718,6 +7840,12 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+            "license": "BSD-2-Clause"
+        },
         "node_modules/webpack": {
             "version": "5.97.1",
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.97.1.tgz",
@@ -7899,6 +8027,16 @@
                 "node": ">=18"
             }
         },
+        "node_modules/whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "license": "MIT",
+            "dependencies": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
+            }
+        },
         "node_modules/which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -8071,7 +8209,6 @@
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
             "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
-            "dev": true,
             "dependencies": {
                 "sax": ">=0.6.0",
                 "xmlbuilder": "~11.0.0"
@@ -8084,7 +8221,6 @@
             "version": "11.0.1",
             "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
             "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-            "dev": true,
             "engines": {
                 "node": ">=4.0"
             }

--- a/package.json
+++ b/package.json
@@ -657,6 +657,7 @@
         "@azure/arm-features": "^3.1.0",
         "@azure/arm-monitor": "^7.0.0",
         "@azure/arm-msi": "^2.1.0",
+        "@azure/arm-resourcegraph": "^4.2.1",
         "@azure/arm-resources": "^5.2.0",
         "@azure/arm-resources-subscriptions": "^2.1.0",
         "@azure/arm-storage": "^18.3.0",

--- a/src/commands/utils/arm.ts
+++ b/src/commands/utils/arm.ts
@@ -14,6 +14,7 @@ import { ReadyAzureSessionProvider } from "../../auth/types";
 import { Errorable, getErrorMessage } from "./errorable";
 import { ComputeManagementClient } from "@azure/arm-compute";
 import { ContainerServiceFleetClient } from "@azure/arm-containerservicefleet";
+import { ResourceGraphClient } from "@azure/arm-resourcegraph";
 
 export function getSubscriptionClient(sessionProvider: ReadyAzureSessionProvider): SubscriptionClient {
     return new SubscriptionClient(getCredential(sessionProvider), { endpoint: getArmEndpoint() });
@@ -35,6 +36,10 @@ export function getAksClient(
     subscriptionId: string,
 ): ContainerServiceClient {
     return new ContainerServiceClient(getCredential(sessionProvider), subscriptionId, { endpoint: getArmEndpoint() });
+}
+
+export function getGraphResourceClient(sessionProvider: ReadyAzureSessionProvider): ResourceGraphClient {
+    return new ResourceGraphClient(getCredential(sessionProvider));
 }
 
 export function getAksFleetClient(

--- a/src/commands/utils/azureResources.ts
+++ b/src/commands/utils/azureResources.ts
@@ -1,9 +1,10 @@
 import { GenericResourceExpanded } from "@azure/arm-resources";
-import { getResourceManagementClient, listAll, getAksFleetClient } from "./arm";
+import { getResourceManagementClient, listAll, getAksFleetClient, getGraphResourceClient } from "./arm";
 import { Errorable, map as errmap } from "./errorable";
 import { parseResource } from "../../azure-api-utils";
 import { ReadyAzureSessionProvider } from "../../auth/types";
 import { FleetMember } from "@azure/arm-containerservicefleet";
+import { AksCluster } from "./config";
 
 export const clusterProvider = "Microsoft.ContainerService";
 export const acrProvider = "Microsoft.ContainerRegistry";
@@ -48,6 +49,34 @@ export async function getResources(
     const client = getResourceManagementClient(sessionProvider, subscriptionId);
     const list = await listAll(client.resources.list({ filter: `resourceType eq '${resourceType}'` }));
     return errmap(list, (resources) => resources.filter(isDefinedResource).map(asResourceWithGroup));
+}
+
+export async function getClusterAndFleetResourcesFromGraphAPI(
+    sessionProvider: ReadyAzureSessionProvider,
+    subscriptionId: string,
+): Promise<Errorable<AksCluster[]>> {
+    const client = getGraphResourceClient(sessionProvider);
+    const query = {
+        query: `Resources | where type =~ '${clusterResourceType}' or type =~ '${fleetResourceType}' | project id, name, location, resourceGroup, subscriptionId, type`,
+        subscriptions: [subscriptionId],
+    };
+
+    try {
+        const response = await client.resources(query);
+
+        const aksClusters: AksCluster[] = response.data.map((resource: AksCluster) => ({
+            id: resource.id,
+            name: resource.name,
+            location: resource.location,
+            resourceGroup: resource.resourceGroup,
+            subscriptionId: resource.subscriptionId,
+            type: resource.type,
+        }));
+        return errmap({ succeeded: true, result: aksClusters }, (resources) => resources);
+    } catch (error) {
+        console.error("Error fetching AKS clusters:", error);
+        return { succeeded: false, error: error as string };
+    }
 }
 
 function isDefinedResource(resource: GenericResourceExpanded): resource is DefinedResource {

--- a/src/commands/utils/clusterfilter.ts
+++ b/src/commands/utils/clusterfilter.ts
@@ -1,0 +1,117 @@
+import { IActionContext } from "@microsoft/vscode-azext-utils";
+import { ClusterQuickPickItem, getAksClusterSubscriptionNode } from "../utils/clusters";
+import { failed } from "../utils/errorable";
+import * as vscode from "vscode";
+import * as k8s from "vscode-kubernetes-tools-api";
+import { getExtension } from "../utils/host";
+import { longRunning } from "../utils/host";
+import { getGraphResourceClient } from "../utils/arm";
+import { getReadySessionProvider } from "../../auth/azureAuth";
+import { AksCluster, getFilteredClusters, setFilteredClusters } from "./config";
+import { parseResource, parseSubId } from "../../azure-api-utils";
+import { ResourceGraphClient } from "@azure/arm-resourcegraph";
+
+export default async function aksClusterFilter(_context: IActionContext, target: unknown): Promise<void> {
+    const cloudExplorer = await k8s.extension.cloudExplorer.v1;
+
+    const subscriptionNode = getAksClusterSubscriptionNode(target, cloudExplorer);
+    if (failed(subscriptionNode)) {
+        vscode.window.showErrorMessage(subscriptionNode.error);
+        return;
+    }
+
+    const extension = getExtension();
+    if (failed(extension)) {
+        vscode.window.showErrorMessage(extension.error);
+        return;
+    }
+
+    const sessionProvider = await getReadySessionProvider();
+    if (failed(sessionProvider)) {
+        vscode.window.showErrorMessage(sessionProvider.error);
+        return;
+    }
+
+    const graphServiceClient = getGraphResourceClient(sessionProvider.result);
+    let clusterList: AksCluster[];
+
+    await longRunning(`Getting AKS Cluster list for ${subscriptionNode.result.name}`, async () => {
+        const aksClusters = await fetchAksClusters(graphServiceClient, subscriptionNode.result.subscriptionId);
+        clusterList = aksClusters;
+    });
+
+    const filteredClusters = await getUniqueClusters();
+
+    const quickPickItems: ClusterQuickPickItem[] = clusterList!.map((cluster: AksCluster) => {
+        return {
+            label: cluster.name || "",
+            description: cluster.name,
+            picked: filteredClusters.some((filtered) => filtered.clusterName === cluster.name),
+            Cluster: {
+                clusterName: cluster.name || "",
+                subscriptionId: cluster.subscriptionId || "",
+            },
+        };
+    });
+
+    // show picked items at the top
+    quickPickItems.sort((itemA, itemB) => (itemA.picked === itemB.picked ? 0 : itemA.picked ? -1 : 1));
+
+    const selectedItems = await vscode.window.showQuickPick(quickPickItems, {
+        canPickMany: true,
+        placeHolder: "Select Cluster",
+    });
+
+    if (!selectedItems) {
+        return;
+    }
+
+    // Set Cluster Instance
+    const newFilteredClusters = [
+        ...selectedItems.map((item) => item.Cluster), // Retain filters in any other tenants.
+    ];
+
+    await setFilteredClusters(newFilteredClusters);
+}
+
+async function fetchAksClusters(
+    graphServiceClient: ResourceGraphClient,
+    subscriptionId: string,
+): Promise<AksCluster[]> {
+    const query = {
+        query: "Resources | where type =~ 'Microsoft.ContainerService/managedClusters' | project name, location, resourceGroup, subscriptionId",
+        subscriptions: [subscriptionId],
+    };
+
+    try {
+        const response = await graphServiceClient.resources(query);
+
+        const aksClusters: AksCluster[] = response.data.map((resource: AksCluster) => ({
+            id: resource.id,
+            name: resource.name,
+            location: resource.location,
+            resourceGroup: resource.resourceGroup,
+            subscriptionId: resource.subscriptionId,
+        }));
+
+        return aksClusters;
+    } catch (error) {
+        console.error("Error fetching AKS clusters:", error);
+        return [];
+    }
+}
+
+async function getUniqueClusters() {
+    const filteredClusters = getFilteredClusters();
+
+    if (filteredClusters && Array.isArray(filteredClusters)) {
+        // Use a Map to remove duplicates based on subid and ClusterName
+        const uniqueClusters = Array.from(
+            new Map(filteredClusters.map((item) => [`${item.subscriptionId}-${item.clusterName}`, item])).values(),
+        );
+
+        return uniqueClusters;
+    }
+
+    return [];
+}

--- a/src/commands/utils/clusterfilter.ts
+++ b/src/commands/utils/clusterfilter.ts
@@ -8,7 +8,6 @@ import { longRunning } from "../utils/host";
 import { getGraphResourceClient } from "../utils/arm";
 import { getReadySessionProvider } from "../../auth/azureAuth";
 import { AksCluster, getFilteredClusters, setFilteredClusters } from "./config";
-import { parseResource, parseSubId } from "../../azure-api-utils";
 import { ResourceGraphClient } from "@azure/arm-resourcegraph";
 
 export default async function aksClusterFilter(_context: IActionContext, target: unknown): Promise<void> {

--- a/src/commands/utils/clusterfilter.ts
+++ b/src/commands/utils/clusterfilter.ts
@@ -78,7 +78,7 @@ async function fetchAksClusters(
     subscriptionId: string,
 ): Promise<AksCluster[]> {
     const query = {
-        query: "Resources | where type =~ 'Microsoft.ContainerService/managedClusters' | project name, location, resourceGroup, subscriptionId",
+        query: "Resources | where type =~ 'Microsoft.ContainerService/managedClusters' | project id, name, location, resourceGroup, subscriptionId, type",
         subscriptions: [subscriptionId],
     };
 
@@ -91,6 +91,7 @@ async function fetchAksClusters(
             location: resource.location,
             resourceGroup: resource.resourceGroup,
             subscriptionId: resource.subscriptionId,
+            type: resource.type,
         }));
 
         return aksClusters;

--- a/src/commands/utils/clusterfilter.ts
+++ b/src/commands/utils/clusterfilter.ts
@@ -33,7 +33,10 @@ export default async function aksClusterFilter(_context: IActionContext, target:
     let clusterList: AksClusterAndFleet[] = [];
 
     await longRunning(`Getting AKS Cluster list for ${subscriptionNode.result.name}`, async () => {
-        const aksClusters = await getClusterAndFleetResourcesFromGraphAPI(sessionProvider.result, subscriptionNode.result.subscriptionId);
+        const aksClusters = await getClusterAndFleetResourcesFromGraphAPI(
+            sessionProvider.result,
+            subscriptionNode.result.subscriptionId,
+        );
         if (failed(aksClusters)) {
             vscode.window.showErrorMessage(aksClusters.error);
             return;

--- a/src/commands/utils/config.ts
+++ b/src/commands/utils/config.ts
@@ -49,6 +49,7 @@ export interface AksCluster {
     location: string;
     resourceGroup: string;
     subscriptionId: string;
+    type: string;
 }
 
 const onFilteredSubscriptionsChangeEmitter = new vscode.EventEmitter<void>();

--- a/src/commands/utils/config.ts
+++ b/src/commands/utils/config.ts
@@ -43,7 +43,7 @@ export interface ClusterFilter {
     clusterName: string;
 }
 
-export interface AksCluster {
+export interface AksClusterAndFleet {
     id: string;
     name: string;
     location: string;

--- a/src/commands/utils/config.ts
+++ b/src/commands/utils/config.ts
@@ -38,6 +38,19 @@ export interface SubscriptionFilter {
     subscriptionId: string;
 }
 
+export interface ClusterFilter {
+    subscriptionId: string;
+    clusterName: string;
+}
+
+export interface AksCluster {
+    id: string;
+    name: string;
+    location: string;
+    resourceGroup: string;
+    subscriptionId: string;
+}
+
 const onFilteredSubscriptionsChangeEmitter = new vscode.EventEmitter<void>();
 
 export function getFilteredSubscriptionsChangeEvent() {


### PR DESCRIPTION
Hiya @JunyuQian 

its all the work done in https://github.com/JunyuQian/vscode-aks-tools/pull/2, https://github.com/JunyuQian/vscode-aks-tools/pull/3, https://github.com/JunyuQian/vscode-aks-tools/pull/4

Following changes uses `https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-arm-resourcegraph/2.0.0/index.html` arm resource graph api, which is way faster then iterator api.

I can see the difference in loading the filter as well, have a try around with this change, also some minor filter with it, specifically the whole ManagedCluster of ContainerService type was too much for this instance.

This PR enhances and add `fetchAksClusters` function by structuring the response data into a well-defined `AksCluster` interface rather then the `containerServiceClient` call which was very slow. This ensures better type safety, readability, and maintainability of the AKS cluster data retrieval process.  

### Changes Introduced  

- Defined an `AksCluster` interface to enforce a structured object type.  
- Added the `fetchAksClusters` function to return a `Promise<AksCluster[]>` instead of raw `response.data`.  
- Extracted relevant properties (`id, name, location, resourceGroup, subscriptionId`) from the response to match the `AksCluster` type.  
- Improved error handling and logging.  
